### PR TITLE
Replace deprecated UTC timestamp conversion

### DIFF
--- a/obj_idx/dlp_lpm_meta.py
+++ b/obj_idx/dlp_lpm_meta.py
@@ -93,8 +93,13 @@ class DLPMetaData:
             person = self.data.get('creator')
         if self.partial:
             assert person
-            # TODO don't use this deprecated thing
-            starttime = datetime.datetime.utcfromtimestamp(self.data['timestamp']).isoformat()
+            starttime = (
+                datetime.datetime.fromtimestamp(
+                    self.data['timestamp'], datetime.timezone.utc
+                )
+                .replace(tzinfo=None)
+                .isoformat()
+            )
             media = f'live-{person}-{starttime}-{self.data.get("id")}'
         else:
             if person:


### PR DESCRIPTION
Fixes #69.

## Summary

- Replace the deprecated `datetime.datetime.utcfromtimestamp()` call used for partial yt-dlp/LPM metadata.
- Use an explicit UTC conversion while preserving the existing ISO timestamp shape used in generated `live-*` media keys.

## Validation

- `git diff --check`
- `git diff --cached --check`
- `git diff --check HEAD~1..HEAD`
- Not run locally
