### PR TITLE
Return 400 for unknown upload buckets

### DIFF
--- a/obj_idx/api.py
+++ b/obj_idx/api.py
@@ -97,7 +97,8 @@ class Upload(flask_restx.Resource):
         """Upload or get info"""
         exists = False
         checksum = bytes.fromhex(api.payload['checksum'])
-        assert api.payload['bucket'] in app.config['OBJIDX_BUCKETS']
+        if api.payload['bucket'] not in app.config['OBJIDX_BUCKETS']:
+            flask_restx.abort(400, "Unknown bucket", bucket=api.payload['bucket'])
         my_obj = db.Object.query.filter_by(checksum=checksum).one_or_none()
         if my_obj:
             exists = True


### PR DESCRIPTION
Fixes #67.

## Summary

- Return a 400 response when an upload references a bucket that is not configured for the server.
- Keep the existing upload flow unchanged for configured buckets.

## Validation

- `git diff --check`
- `git diff --cached --check`
- `git diff --check HEAD~1..HEAD`
- `git show --check --stat --oneline HEAD`
- Not run locally