### PR TITLE
Object deletion mechanism (v0.3.8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,38 @@ Notes for client authors:
   so a well‑behaved client that never triggered those crashes is unaffected.
 
 
+## Upgrading to 0.3.8 (object deletion)
+
+0.3.8 adds a real deletion mechanism (issue #23): remove an object's bytes
+from the object store for size reasons while keeping the metadata record.
+
+- **Requires a simpler-objects cluster >= 0.6**, which provides
+  `DELETE /{bucket}/{key}` on the locator. On a secured cluster (auth enabled),
+  the client's locator identity additionally needs the `delete` permission on
+  the bucket. Older clusters: everything else keeps working; only the new
+  delete flow will fail.
+- **No database migration** and no API contract changes other than
+  `PUT /object/{uuid}/`: the previously rejected body
+  `{"completed": true, "deleted": true}` (was `400`) now reports that the
+  bytes of a *completed* object were removed from the store, setting
+  `deleted`; on a not-yet-completed object it returns `409`. Setting
+  `deleted` alone is unchanged (clears a failed upload; still a no-op on
+  completed objects).
+- **New CLI subcommand**: `obj-idx-client delete <object-uuid> ...` (or
+  `obj-idx-client delete -u <original-url> ...` to resolve objects by their
+  source URL). Like `scrub`, it needs the locator base via `--s3` or
+  `OBJIDX_S3`. It DELETEs on the locator — retrying while the locator answers
+  `503` (an object server was unreachable/busy, so a copy may survive) — and
+  only then marks the record deleted. `RETRY-LATER` output means exactly
+  that: run the same command again once the cluster is healthy.
+- **Deletion is permanent.** The object store keeps a checksum tombstone, so
+  re-uploading content with the same key is refused there (`409`), matching
+  objectindex's own `410` on re-upload of a deleted object.
+- **Legacy "deleted" records**: objects marked deleted before 0.3.8 never had
+  their bytes removed. Running `obj-idx-client delete` on them purges the
+  bytes and leaves the record as is.
+
+
 ## Interim infrastructure
 
 Hardware and such:
@@ -386,7 +418,7 @@ Essentially, the lifecycle state machine of an object looks something like this:
 
 The initial client may retry step 2 as many times as needed; however to start from scratch the object needs to be put in "retry" mode (completed: false, deleted: true) as described above.
 
-Finally, once an object is in normal state, the object may be noted as permenantly deleted intentionally (i.e. so no option/desire for retry) by putting it in deleted state (completed: true, deleted: true) - putting it in this state doesn't actually delete it from object store though.
+Finally, once an object is in normal state, it may be permanently deleted intentionally (i.e. no option/desire for retry): the client first DELETEs the bytes on the simpler-objects locator (retrying while it answers 503, until 204/404 confirms every copy is gone), then reports it by PUTting `{"completed": true, "deleted": true}`, landing the object in deleted state (completed: true, deleted: true) — record kept, bytes gone. `obj-idx-client delete` automates this. Note that PUTting `{"deleted": true}` *alone* still does **not** delete a completed object (that no-op is scrub `--clear`'s guard against clearing an upload that completed in the meantime), and records marked deleted before 0.3.8 may still have bytes in the store until `obj-idx-client delete` is run on them.
 
 ### slow json lookups
 

--- a/ansible/inventory/hosts.example.yml
+++ b/ansible/inventory/hosts.example.yml
@@ -10,7 +10,7 @@ all:
 
     # The one knob you change to upgrade. The playbook pins the package to this
     # git tag; bump it and re-run the playbook to upgrade.
-    objectindex_version: v0.3.2
+    objectindex_version: v0.3.8
 
   children:
 

--- a/ansible/roles/objectindex_api/defaults/main.yml
+++ b/ansible/roles/objectindex_api/defaults/main.yml
@@ -1,6 +1,6 @@
 # Package source. Bump objectindex_version to upgrade; pip detects the changed
 # ref and reinstalls. Idempotent at the same tag.
-objectindex_version: v0.3.2
+objectindex_version: v0.3.8
 objectindex_git_url: https://github.com/ctengel/objectindex
 
 # Install layout. The systemd unit uses %h/venv as the default venv path;

--- a/obj_idx/api.py
+++ b/obj_idx/api.py
@@ -47,7 +47,7 @@ def escape_like_prefix(value):
 
 app = FastAPI(
     title="Object Index API",
-    version="0.3.5",
+    version="0.3.8",
     description="API for storing info about Objects",
 )
 
@@ -254,22 +254,43 @@ def get_object(obj_uuid: uuid.UUID, session: Session = Depends(get_session)):
 
 @app.put("/object/{obj_uuid}/", response_model=ObjectRead,
          responses={
-             400: {"model": DetailResponse,
-                   "description": "Cannot set both completed and deleted"},
              404: {"model": DetailResponse},
              409: {"model": DetailResponse,
-                   "description": "Object already cleared/deleted"},
+                   "description": "Object already cleared/deleted, or a "
+                                  "data-deletion report for an upload that "
+                                  "never completed"},
          })
 def update_object(obj_uuid: uuid.UUID,
                   payload: ObjectUpdate,
                   session: Session = Depends(get_session)):
-    """Let us know an upload is completed (or deleted)"""
+    """Let us know an upload is completed (or deleted)
+
+    Setting both ``completed`` and ``deleted`` reports that the bytes of a
+    *completed* object were removed from the object store (the client DELETEd
+    them via the simpler-objects locator first); the record is kept with
+    ``deleted`` set. Setting ``deleted`` alone still only clears a failed
+    upload and remains a no-op on completed objects.
+    """
     # TODO(#96): serialize concurrent clear/complete with a row lock
     my_obj = session.get(Object, obj_uuid)
     if my_obj is None:
         raise HTTPException(status_code=404, detail="Object not found")
     new_completed = payload.completed
     new_deleted = payload.deleted
+    if new_completed and new_deleted:
+        # A data-deletion report: the client removed the bytes of a completed
+        # object from the object store and asserts the target state. Kept
+        # distinct from deleted-only so scrub --clear's completed-in-the-
+        # meantime race guard (silent no-op below) survives.
+        if not my_obj.completed:
+            raise HTTPException(status_code=409,
+                                detail="Upload not completed; clear it with "
+                                       "deleted only (scrub --clear)")
+        if not my_obj.deleted:
+            my_obj.deleted = True
+            session.commit()
+            session.refresh(my_obj)
+        return my_obj
     if new_completed and my_obj.deleted:
         # Upload was cleared/deleted (perhaps accidentally) but the bytes
         # finished landing afterwards; surface the conflict instead of
@@ -278,9 +299,6 @@ def update_object(obj_uuid: uuid.UUID,
                             detail="Object was cleared/deleted; "
                                    "completion rejected")
     if not my_obj.completed and not my_obj.deleted:
-        if new_completed and new_deleted:
-            raise HTTPException(status_code=400,
-                                detail="Cannot set both completed and deleted")
         if new_completed or new_deleted:
             if new_completed:
                 my_obj.completed = True

--- a/obj_idx/cli.py
+++ b/obj_idx/cli.py
@@ -48,8 +48,39 @@ def get_s3_base(cli_value=None):
     """Resolve the simpler-objects base URL from --s3 or OBJIDX_S3"""
     base = cli_value or os.environ.get('OBJIDX_S3')
     if not base:
-        raise SystemExit("scrub requires --s3 or the OBJIDX_S3 environment variable")
+        raise SystemExit("requires --s3 or the OBJIDX_S3 environment variable")
     return base if base.endswith('/') else base + '/'
+
+
+def _delete(obj_idx, args):
+    s3_base = get_s3_base(args.s3)
+    any_error = False
+    if args.url:
+        objids = []
+        for url in args.item:
+            files = obj_idx.search_files({'url': url})
+            found = [f.object['uuid'] for f in files if f.object]
+            if not found:
+                print(url, 'NOT-FOUND')
+                any_error = True
+            objids.extend(found)
+        # A URL's files may share an object with another URL's; delete once.
+        objids = list(dict.fromkeys(objids))
+    else:
+        objids = args.item
+    for objid in objids:
+        try:
+            done = client.delete_object_data(obj_idx, objid, s3_base)
+        except (client.clilib.requests.RequestException, ValueError) as exc:
+            print(objid, 'ERROR', exc)
+            any_error = True
+            continue
+        if done:
+            print(objid, 'DELETED')
+        else:
+            print(objid, 'RETRY-LATER')
+            any_error = True
+    return 1 if any_error else 0
 
 
 def _scrub(obj_idx, args):
@@ -101,6 +132,12 @@ def cli():
     parser_check.add_argument('-r', '--rm', action='store_true')
     parser_check.add_argument('filename', nargs='+')
     parser_check.set_defaults(func=_check)
+    parser_delete = subparsers.add_parser('delete')
+    parser_delete.add_argument('-u', '--url', action='store_true',
+                               help='arguments are original URLs, not object UUIDs')
+    parser_delete.add_argument('--s3')
+    parser_delete.add_argument('item', nargs='+')
+    parser_delete.set_defaults(func=_delete)
     parser_scrub = subparsers.add_parser('scrub')
     parser_scrub.add_argument('bucket', nargs='+')
     parser_scrub.add_argument('--all', action='store_true')

--- a/obj_idx/client.py
+++ b/obj_idx/client.py
@@ -7,6 +7,7 @@ import socket
 import pathlib
 import mimetypes
 import datetime
+import time
 import warnings
 from dataclasses import dataclass
 from enum import Enum
@@ -24,7 +25,7 @@ from simpler_objects.client import (
 from . import clilib
 from .common import is_valid_url, reconcile_mime_ext, get_mime, GENERIC_MIME
 
-SW_STRING = 'OIC-0.3.7'
+SW_STRING = 'OIC-0.3.8'
 
 def get_mime_data(file_path: pathlib.Path) -> str:
     """Determine mime type based on file data"""
@@ -245,6 +246,69 @@ def head_locator(s3_base: str, bucket: str, key: str, timeout: int = clilib.TIME
     """
     url = urljoin(s3_base, f"{bucket}/{key}")
     return clilib.requests.head(url, allow_redirects=True, timeout=timeout)
+
+
+# The locator fans a DELETE out to every object server (8 s each), so allow
+# well beyond clilib.TIMEOUT; 64 also matches simpler-objects' Retry-After.
+DELETE_TIMEOUT = 64
+# Ceiling on honoring a server-supplied Retry-After between delete attempts.
+DELETE_RETRY_CAP = 120
+
+
+def delete_locator(s3_base: str, bucket: str, key: str,
+                   timeout: int = DELETE_TIMEOUT):
+    """DELETE an object on the simpler-objects locator.
+
+    Unlike GET/HEAD/PUT this is not redirected: the locator itself sends the
+    DELETE to every object server, since each replica must go. Returns the raw
+    requests.Response. 204 means every copy is gone, 404 no copy anywhere,
+    503 retriable (a copy may survive); the caller interprets these (we do
+    not raise).
+    """
+    url = urljoin(s3_base, f"{bucket}/{key}")
+    return clilib.requests.delete(url, allow_redirects=False, timeout=timeout)
+
+
+def delete_object_data(obj_idx: clilib.ObjectIndex, objid, s3_base: str,
+                       max_attempts: int = 5) -> bool:
+    """Delete an object's bytes from the store, keeping the metadata record.
+
+    DELETEs on the locator until it confirms 204/404 (503 means a copy may
+    survive, so we sleep per its Retry-After and try again), then reports the
+    deletion to ObjectIndex with the combined completed+deleted PUT. Also
+    works on objects already marked deleted whose bytes were never removed.
+    Returns True on success, or False when the retry budget ran out before
+    the store confirmed -- the record is then left unmarked; run again later.
+    Raises ValueError for a never-completed object (clear those with scrub
+    --clear instead: deleting mid-upload would tombstone the key and block
+    the retry re-upload) and HTTPError on any other failure.
+    """
+    my_object = obj_idx.get_object(objid)
+    if not my_object['completed']:
+        raise ValueError(f"object {objid} upload not completed; "
+                         "use scrub --clear instead")
+    attempts = 0
+    while True:
+        resp = delete_locator(s3_base, my_object['bucket'], my_object['key'])
+        if resp.status_code in (204, 404):
+            break
+        if resp.status_code != 503:
+            # e.g. 401/403: the locator identity lacks the `delete` permission
+            resp.raise_for_status()
+            raise clilib.requests.HTTPError(
+                f"unexpected HTTP {resp.status_code} deleting "
+                f"{my_object['bucket']}/{my_object['key']}")
+        attempts += 1
+        if attempts >= max_attempts:
+            return False
+        retry_after = resp.headers.get('Retry-After', '')
+        time.sleep(min(int(retry_after) if retry_after.isdigit() else 64,
+                       DELETE_RETRY_CAP))
+    updated = obj_idx.put_object(objid, {"completed": True, "deleted": True})
+    if not updated.get('deleted'):
+        raise clilib.requests.HTTPError(
+            f"object {objid} bytes deleted but record not marked")
+    return True
 
 
 class ScrubCategory(str, Enum):

--- a/obj_idx/clilib.py
+++ b/obj_idx/clilib.py
@@ -133,7 +133,9 @@ class ObjectIndex:
         return fileobj
 
     def put_object(self, object_uuid: uuid.UUID, info: dict):
-        """PUT/PATCH an object (e.g. {"completed": True} or {"deleted": True})"""
+        """PUT/PATCH an object (e.g. {"completed": True} or {"deleted": True};
+        {"completed": True, "deleted": True} reports a completed object's
+        bytes were deleted from the object store)"""
         return self.put(f"object/{object_uuid}/", json=info)
 
     def search_files(self, params):

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: Object Index API
   description: API for storing info about Objects
-  version: '0.1'
+  version: '0.3.8'
 paths:
   /upload/:
     post:
@@ -178,7 +178,13 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
     put:
       summary: Update Object
-      description: Let us know an upload is completed (or deleted)
+      description: >
+        Let us know an upload is completed (or deleted). Setting both
+        `completed` and `deleted` reports that the bytes of a *completed*
+        object were removed from the object store (the client DELETEd them
+        via the simpler-objects locator first); the record is kept with
+        `deleted` set. Setting `deleted` alone still only clears a failed
+        upload and remains a no-op on completed objects.
       operationId: update_object_object__obj_uuid___put
       parameters:
       - name: obj_uuid
@@ -201,18 +207,19 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ObjectRead'
-        '400':
-          description: Cannot set both completed and deleted
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DetailResponse'
         '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/DetailResponse'
           description: Not Found
+        '409':
+          description: Object already cleared/deleted, or a data-deletion
+            report for an upload that never completed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DetailResponse'
         '422':
           description: Validation Error
           content:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "objectindex"
-version = "0.3.7"
+version = "0.3.8"
 description = "Object Index allows you to index your objexts in S3"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -20,7 +20,7 @@ dependencies = [
   'sqlmodel >= 0.0.38',
   'flask >= 2.1',
   'requests >= 2.27',
-  'simpler-objects[client] >= 0.4',
+  'simpler-objects[client] >= 0.6',
   'psycopg2 >= 2.9',
   'sqlalchemy >= 2.0',
   'file-magic >= 0.4'

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -400,11 +400,67 @@ def test_put_deleted(client):
     assert resp.json()["deleted"] is True
 
 
-def test_put_both_true_rejected(client):
+def test_put_both_reports_data_deletion(client):
+    # completed+deleted together report that the client removed the bytes of
+    # a completed object from the object store; the record is kept.
+    content = b"delete my bytes"
+    resp1, _ = _upload(client, content=content)
+    obj_url = resp1.json()["upload"]["finished"]
+    assert _complete(client, obj_url).status_code == 200
+
+    resp = client.put(obj_url, json={"completed": True, "deleted": True})
+    assert resp.status_code == 200
+    assert resp.json()["deleted"] is True
+    obj = client.get(obj_url).json()
+    assert obj["completed"] is True
+    assert obj["deleted"] is True
+
+    # download now 410s, and re-upload of the same content is refused --
+    # matching the store's tombstone, which would 409 the re-PUT anyway
+    obj_uuid = obj["uuid"]
+    assert client.get(f"/object/{obj_uuid}/download").status_code == 410
+    resp2, _ = _upload(client, content=content, url="file://host/again.txt")
+    assert resp2.status_code == 410
+
+    # idempotent: reporting again is fine (retried deletes end here too)
+    assert client.put(obj_url,
+                      json={"completed": True, "deleted": True}).status_code == 200
+
+
+def test_put_both_on_incomplete_409(client):
+    # A never-completed upload must not be data-deleted (the store tombstone
+    # would permanently block the retry re-PUT); clear it with deleted only.
     resp1, _ = _upload(client)
     obj_url = resp1.json()["upload"]["finished"]
     resp = client.put(obj_url, json={"completed": True, "deleted": True})
-    assert resp.status_code >= 400
+    assert resp.status_code == 409
+    obj = client.get(obj_url).json()
+    assert obj["completed"] is False
+    assert obj["deleted"] is False
+
+
+def test_put_both_on_cleared_409(client):
+    # Same for an upload already cleared into retry mode.
+    resp1, _ = _upload(client, content=b"cleared upload")
+    obj_url = resp1.json()["upload"]["finished"]
+    assert client.put(obj_url, json={"deleted": True}).status_code == 200
+    resp = client.put(obj_url, json={"completed": True, "deleted": True})
+    assert resp.status_code == 409
+    obj = client.get(obj_url).json()
+    assert obj["completed"] is False
+    assert obj["deleted"] is True
+
+
+def test_put_deleted_only_still_noop_on_completed(client):
+    # scrub --clear's race guard: deleted alone must stay a silent no-op on a
+    # completed object so a clear that lost the race is detectable.
+    resp1, _ = _upload(client, content=b"completed meanwhile")
+    obj_url = resp1.json()["upload"]["finished"]
+    assert _complete(client, obj_url).status_code == 200
+    resp = client.put(obj_url, json={"deleted": True})
+    assert resp.status_code == 200
+    assert resp.json()["deleted"] is False
+    assert client.get(obj_url).json()["deleted"] is False
 
 
 def test_put_completed_after_deleted_rejected(client):

--- a/tests/test_cli_and_meta.py
+++ b/tests/test_cli_and_meta.py
@@ -117,6 +117,70 @@ def test_cli_check_rm_unlinks_file():
 
 
 # ---------------------------------------------------------------------------
+# cli._delete
+# ---------------------------------------------------------------------------
+
+def test_cli_delete_by_uuid(capsys):
+    mock_oi = _mock_oi()
+    args = argparse.Namespace(item=[OBJ_UUID], url=False, s3='http://s3.test/')
+    with patch('obj_idx.cli.client.delete_object_data',
+               return_value=True) as mock_del:
+        rc = cli._delete(mock_oi, args)
+    mock_del.assert_called_once_with(mock_oi, OBJ_UUID, 'http://s3.test/')
+    assert rc == 0
+    assert 'DELETED' in capsys.readouterr().out
+
+
+def test_cli_delete_by_url_resolves_objects(capsys):
+    mock_oi = _mock_oi()
+    mock_oi.search_files.return_value = [_mock_file(), _mock_file()]
+    args = argparse.Namespace(item=['file://host/a.txt'], url=True,
+                              s3='http://s3.test/')
+    with patch('obj_idx.cli.client.delete_object_data',
+               return_value=True) as mock_del:
+        rc = cli._delete(mock_oi, args)
+    # both files share one object -> deleted once
+    mock_del.assert_called_once_with(mock_oi, OBJ_UUID, 'http://s3.test/')
+    assert rc == 0
+
+
+def test_cli_delete_retry_later_nonzero_exit(capsys):
+    mock_oi = _mock_oi()
+    args = argparse.Namespace(item=[OBJ_UUID], url=False, s3='http://s3.test/')
+    with patch('obj_idx.cli.client.delete_object_data', return_value=False):
+        rc = cli._delete(mock_oi, args)
+    assert rc == 1
+    assert 'RETRY-LATER' in capsys.readouterr().out
+
+
+def test_cli_delete_error_continues(capsys):
+    mock_oi = _mock_oi()
+    other_uuid = 'aaaaaaaa-0000-0000-0000-000000000009'
+    args = argparse.Namespace(item=[OBJ_UUID, other_uuid], url=False,
+                              s3='http://s3.test/')
+    with patch('obj_idx.cli.client.delete_object_data',
+               side_effect=[ValueError('not completed'), True]) as mock_del:
+        rc = cli._delete(mock_oi, args)
+    assert mock_del.call_count == 2
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert 'ERROR' in out
+    assert 'DELETED' in out
+
+
+def test_cli_delete_url_not_found(capsys):
+    mock_oi = _mock_oi()
+    mock_oi.search_files.return_value = []
+    args = argparse.Namespace(item=['file://host/nope.txt'], url=True,
+                              s3='http://s3.test/')
+    with patch('obj_idx.cli.client.delete_object_data') as mock_del:
+        rc = cli._delete(mock_oi, args)
+    mock_del.assert_not_called()
+    assert rc == 1
+    assert 'NOT-FOUND' in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
 # cli.get_s3_base / cli._scrub
 # ---------------------------------------------------------------------------
 

--- a/tests/test_client_io.py
+++ b/tests/test_client_io.py
@@ -367,3 +367,95 @@ def test_download_verifies_checksum(dl_digest):
             # digest-present: dl_cksum.hex() == file.object['checksum']
             # digest-none: the `if dl_cksum:` guard is skipped; disk re-hash verifies
             client.download(mock_oi, 'http://example.com/v.mp4')
+
+
+# ---------------------------------------------------------------------------
+# delete_object_data
+# ---------------------------------------------------------------------------
+
+S3_BASE = 'http://s3.test/'
+
+
+def _locator_resp(status_code, retry_after=None):
+    resp = Mock()
+    resp.status_code = status_code
+    resp.headers = {'Retry-After': retry_after} if retry_after else {}
+    return resp
+
+
+def _deletable_obj_idx(completed=True, deleted=False):
+    mock_oi = _mock_obj_idx()
+    mock_oi.get_object.return_value = _make_object_dict(completed=completed,
+                                                        deleted=deleted)
+    mock_oi.put_object.return_value = _make_object_dict(deleted=True)
+    return mock_oi
+
+
+def test_delete_204_marks_deleted():
+    mock_oi = _deletable_obj_idx()
+    with patch('obj_idx.client.delete_locator',
+               return_value=_locator_resp(204)) as mock_del:
+        assert client.delete_object_data(mock_oi, OBJ_UUID, S3_BASE) is True
+    mock_del.assert_called_once_with(S3_BASE, 'bucket1', f'{CKSUM_HEX}-a.txt')
+    mock_oi.put_object.assert_called_once_with(
+        OBJ_UUID, {"completed": True, "deleted": True})
+
+
+def test_delete_404_marks_deleted():
+    # No copy anywhere still reaches the target state (e.g. re-running after
+    # a crash between the store delete and the report, or a legacy row).
+    mock_oi = _deletable_obj_idx()
+    with patch('obj_idx.client.delete_locator', return_value=_locator_resp(404)):
+        assert client.delete_object_data(mock_oi, OBJ_UUID, S3_BASE) is True
+    mock_oi.put_object.assert_called_once()
+
+
+def test_delete_already_marked_still_deletes_bytes():
+    # The purge path for records marked deleted whose bytes were never removed.
+    mock_oi = _deletable_obj_idx(deleted=True)
+    with patch('obj_idx.client.delete_locator',
+               return_value=_locator_resp(204)) as mock_del:
+        assert client.delete_object_data(mock_oi, OBJ_UUID, S3_BASE) is True
+    mock_del.assert_called_once()
+
+
+def test_delete_retries_503_honoring_retry_after():
+    mock_oi = _deletable_obj_idx()
+    responses = [_locator_resp(503, retry_after='7'),
+                 _locator_resp(503, retry_after='not-a-number'),
+                 _locator_resp(204)]
+    with patch('obj_idx.client.delete_locator', side_effect=responses):
+        with patch('obj_idx.client.time.sleep') as mock_sleep:
+            assert client.delete_object_data(mock_oi, OBJ_UUID, S3_BASE) is True
+    assert [c.args[0] for c in mock_sleep.call_args_list] == [7, 64]
+    mock_oi.put_object.assert_called_once()
+
+
+def test_delete_503_budget_exhausted_returns_false():
+    # A copy may survive: the record must NOT be marked deleted.
+    mock_oi = _deletable_obj_idx()
+    with patch('obj_idx.client.delete_locator',
+               return_value=_locator_resp(503, retry_after='1')):
+        with patch('obj_idx.client.time.sleep'):
+            assert client.delete_object_data(mock_oi, OBJ_UUID, S3_BASE,
+                                             max_attempts=3) is False
+    mock_oi.put_object.assert_not_called()
+
+
+def test_delete_403_raises():
+    mock_oi = _deletable_obj_idx()
+    resp = _locator_resp(403)
+    resp.raise_for_status.side_effect = requests.HTTPError('403')
+    with patch('obj_idx.client.delete_locator', return_value=resp):
+        with pytest.raises(requests.HTTPError):
+            client.delete_object_data(mock_oi, OBJ_UUID, S3_BASE)
+    mock_oi.put_object.assert_not_called()
+
+
+def test_delete_incomplete_raises_without_locator_call():
+    mock_oi = _deletable_obj_idx(completed=False)
+    with patch('obj_idx.client.delete_locator') as mock_del:
+        with pytest.raises(ValueError):
+            client.delete_object_data(mock_oi, OBJ_UUID, S3_BASE)
+    mock_del.assert_not_called()
+    mock_oi.put_object.assert_not_called()


### PR DESCRIPTION
Closes #23. Presumes simpler-objects >= 0.6 (PRs ctengel/simpler-objects#84 / ctengel/simpler-objects#85): the locator's fan-out `DELETE /{bucket}/{key}` and, on secured clusters, the `delete` RBAC permission for the client's locator identity.

## Behavior

Deletion is **client-driven**, mirroring the upload flow (the OI API server still never contacts simpler-objects):

1. The client DELETEs `{OBJIDX_S3}{bucket}/{key}` on the locator, sleeping per its `Retry-After` and retrying while it answers 503 (an object server was unreachable/busy — a copy may survive), until 204/404 confirms every copy is gone.
2. It then reports via `PUT /object/{uuid}/` with `{"completed": true, "deleted": true}` — the previously rejected combined payload (was 400) now means "bytes of a *completed* object were removed; keep the record". On a never-completed object it returns 409 (deleting mid-upload would tombstone the key and permanently break the retry re-upload; `scrub --clear` remains the path for those).
3. `{"deleted": true}` **alone is unchanged**: it clears a failed upload and stays a silent no-op on completed objects, preserving scrub `--clear`'s completed-in-the-meantime race guard.

New CLI subcommand: `obj-idx-client delete <object-uuid> ...` (or `-u <original-url> ...`), using `--s3`/`OBJIDX_S3` like scrub. Prints `DELETED` / `RETRY-LATER` / `ERROR` per object; nonzero exit on any failure. `RETRY-LATER` means exactly that — the record is left unmarked until the store confirms, and running `delete` again (also on legacy rows marked deleted before 0.3.8) is safe and idempotent.

`completed=true, deleted=true` now genuinely means "record kept, bytes gone"; the store's checksum tombstone makes re-PUT of the key permanently 409, matching OI's existing 410 on re-upload of a deleted object.

Issue #25 (credential handling) is deliberately **not** touched here — deferred to the #14 auth work.

## Testing

- 30 new/updated tests (API contract for the extended PUT state machine incl. the scrub-guard regression test; client retry/report logic with Retry-After honoring; CLI dispatch). Full suite: 152 passed.
- Verified end-to-end against a live scratch cluster running the simpler-objects `object-delete` branch (v0.6.0): upload → `obj-idx-client delete` → 204, file unlinked, tombstone intact, record `completed+deleted`, download 410, re-upload 410, repeat delete idempotent; never-completed object refused with guidance; object server stopped mid-test → locator 503 honored for 4×64 s then `RETRY-LATER` with the flag untouched → after restart, retry deleted the surviving copy and marked the record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019CLRgNsXYMSKTX7p3BE4Hy